### PR TITLE
works better with resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Splits the Chatlog into In Character (per scene), Rolls (per scene), and Out of 
 
 ## Changelog
 
+### David Zvekic Fork - 
+-- Now works properly with Vance's Resizable Sidebar.
+-- Flush now only deletes the messages from the active TAB, leaving the messages on other tabs clean.  
+
 ### v1.1.0
 
 Added notifications for new messages in inactive tabs.

--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -488,7 +488,9 @@ async function() {
 function checkDeleteChatMessage(e){
     let result =  checkMessageIsVisible(e.data.type);
 	if ((e.data.type==2 || e.data.type==3) && currentTab!="ic") result=false;
+	if(e.data.speaker.scene)
 	if((e.data.speaker.scene!=game.user.viewedScene) && (e.data.type=2 || e.data.type==3)) result=false;
+	
     if(e.data.blind && e.data.whisper.find(element => element == game.userId)==undefined) result=false;
 	console.warn('checkdeleting', e,result);
 	return result;

--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -63,11 +63,11 @@ function isMessageTypeVisible(messageType){
 
 function isMessageVisible(e){
 	const messageType=e.data.type;
-   
+	
 	if (!isMessageTypeVisible(messageType)) return false;
 	
 	if(e.data.speaker.scene)
-	if((messageType==CHAT_MESSAGE_TYPES.IC || CHAT_MESSAGE_TYPES.EMOTE)  && (e.data.speaker.scene!=game.user.viewedScene) ) return false;
+	if((messageType==CHAT_MESSAGE_TYPES.IC || messageType==CHAT_MESSAGE_TYPES.EMOTE)  && (e.data.speaker.scene!=game.user.viewedScene) ) return false;
 
     if(e.data.blind && e.data.whisper.find(element => element == game.userId)==undefined) return false;
 

--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -169,12 +169,13 @@ Hooks.on("createChatMessage", (chatMessage, content) => {
 
   if (chatMessage.data.type == 0) {
     if (currentTab != "rolls" && sceneMatches) {
+	  setRollsNotifyProperties();
       $("#rollsNotification").show();
     }
   }
   else if (chatMessage.data.type == 5) {
     if (currentTab != "rolls" && sceneMatches && chatMessage.data.whisper.length == 0) {
-      $("#rollsNotification").css({'right': ( $("div#sidebar.app").width() / 3).toString() +'px' } );
+       setRollsNotifyProperties();
       $("#rollsNotification").show();
     }
   }
@@ -182,7 +183,7 @@ Hooks.on("createChatMessage", (chatMessage, content) => {
   {
     if (currentTab != "ic" && sceneMatches)
     { 
-      $("#icNotification").css({'right': ($("div#sidebar.app").width()  / 3 * 2).toString() +'px' } );
+      setICNotifyProperties();
       $("#icNotification").show();
     }
   }
@@ -191,7 +192,7 @@ Hooks.on("createChatMessage", (chatMessage, content) => {
     if (salonEnabled && chatMessage.data.type == 4) return;
 
     if (currentTab != "ooc") { 
-      // no adjustment of #oocNotification:right is really needed because its right side does not move.
+      setOOPNotifyProperties();
       $("#oocNotification").show();
     }
   }
@@ -381,11 +382,57 @@ Hooks.on("closeSceneConfig", (app, html, data) => {
   app.object.setFlag('tabbed-chatlog', 'webhook', html.find("input[name ='scenewebhook']")[0].value);
 });
 
+
+Hooks.on('sidebarCollapse',(sidebar,collapsing)=>{
+	if(!collapsing){
+		setALLTabsNotifyProperties();
+	}
+	
+});
+
+
 Hooks.on('ready', () => {
   if (game.modules.get('narrator-tools')) { NarratorTools._msgtype = 2; }
 
   turndown = new TurndownService();
+
+  const sidebar = document.querySelector('#sidebar');
+ 
+  sidebar.addEventListener("mousedown", sidebarMouseDown,false);
+ 
+  function sidebarMouseDown(){
+	  sidebar.addEventListener("mousemove", sidebarMouseMove,false);
+	  sidebar.addEventListener("mouseup", sidebarMouseUp,false);
+  }
+
+  function sidebarMouseUp(){
+	  sidebar.removeEventListener("mousemove", sidebarMouseMove,false);
+	  sidebar.removeEventListener("mouseup", sidebarMouseUp,false);
+  }
+  
+  function sidebarMouseMove(){
+	  setALLTabsNotifyProperties(); 
+  }
+
+
 });
+
+function setICNotifyProperties(){
+	$("#icNotification").css({'right': ($("div#sidebar.app").width()  / 3 * 2).toString() +'px' } );
+};
+function setRollsNotifyProperties(){
+	 $("#rollsNotification").css({'right': ( $("div#sidebar.app").width() / 3).toString() +'px' } );
+};
+function setOOCNotifyProperties(){
+	//NO-OP Nothing to do
+};
+
+function setALLTabsNotifyProperties(){
+  setICNotifyProperties();
+  setRollsNotifyProperties();
+  setOOCNotifyProperties();
+}
+
 
 function shouldHideDueToStreamView() {
   if (game.settings.get("tabbed-chatlog", "hideInStreamView")) {

--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -174,6 +174,7 @@ Hooks.on("createChatMessage", (chatMessage, content) => {
   }
   else if (chatMessage.data.type == 5) {
     if (currentTab != "rolls" && sceneMatches && chatMessage.data.whisper.length == 0) {
+      $("#rollsNotification").css({'right': ( $("div#sidebar.app").width() / 3).toString() +'px' } );
       $("#rollsNotification").show();
     }
   }
@@ -181,6 +182,7 @@ Hooks.on("createChatMessage", (chatMessage, content) => {
   {
     if (currentTab != "ic" && sceneMatches)
     { 
+      $("#icNotification").css({'right': ($("div#sidebar.app").width()  / 3 * 2).toString() +'px' } );
       $("#icNotification").show();
     }
   }
@@ -189,6 +191,7 @@ Hooks.on("createChatMessage", (chatMessage, content) => {
     if (salonEnabled && chatMessage.data.type == 4) return;
 
     if (currentTab != "ooc") { 
+      // no adjustment of #oocNotification:right is really needed because its right side does not move.
       $("#oocNotification").show();
     }
   }

--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -492,7 +492,7 @@ function checkDeleteChatMessage(e){
 	if((e.data.speaker.scene!=game.user.viewedScene) && (e.data.type=2 || e.data.type==3)) result=false;
 	
     if(e.data.blind && e.data.whisper.find(element => element == game.userId)==undefined) result=false;
-	console.warn('checkdeleting', e,result);
+	//console.warn('checkdeleting', e,result);
 	return result;
 }
 


### PR DESCRIPTION
the Jquery will cause the tabbed chatlog to be aware if the sidebar has resized, either via system prefs, or a resizing module such as Vance's Sidebar Resizer.

The resize takes effect the next time a notification appears.   Ideally it would move the notifications in real-time, but people usually don't adjust the sidebar size repeatedly.

Currently the notifications appear at a fixed position regardless of the sidebar width and this can confuse players to click on the wrong Tab, creating confusion.

