### PR TITLE
Polyglot Integration

### DIFF
--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -241,15 +241,23 @@ Hooks.on("preCreateChatMessage", (chatMessage, content) => {
       img = game.data.addresses.remote + "/" + img;
 
       if (!chatMessage.whisper?.length) {
+        let message = chatMessage.content;
+        if (game.modules.get("polyglot")?.active) {
+          import("../polyglot/src/polyglot.js");
+          let lang = PolyGlot.languages[chatMessage.flags.polyglot.language] || chatMessage.flags.polyglot.language
+          if (lang != PolyGlot.defaultLanguage) {
+            message = lang + ": ||" + chatMessage.content + "||";
+          }
+        }
         sendToDiscord(webhook, {
-          content: turndown.turndown(chatMessage.content),
+          content: turndown.turndown(message),
           username: name,
           avatar_url: img
         });
       }
     }
     catch (error) {
-      console.log(error);
+      console.error(error);
     }
   }
   else
@@ -266,15 +274,23 @@ Hooks.on("preCreateChatMessage", (chatMessage, content) => {
       img = game.data.addresses.remote + "/" + img;
 
       if (!chatMessage.whisper?.length) {
+        let message = chatMessage.content;
+        if (game.modules.get("polyglot")?.active) {
+          import("../polyglot/src/polyglot.js");
+          let lang = PolyGlot.languages[chatMessage.flags.polyglot.language] || chatMessage.flags.polyglot.language
+          if (lang != PolyGlot.defaultLanguage) {
+            message = lang + ": ||" + chatMessage.content + "||";
+          }
+        }
         sendToDiscord(webhook, {
-          content: turndown.turndown(chatMessage.content),
+          content: turndown.turndown(message),
           username: game.users.get(chatMessage.user).name,
           avatar_url: img
         });
       }
     }
     catch (error) {
-      console.log(error);
+      console.error(error);
     }
   }
 });


### PR DESCRIPTION
If Polyglot module is active, TC will send messages as "LanguageName: ||MessageContent||", unless it's the system's default language.

Few issues:
- It takes the system's default common language into account only. If a GM wants to run a campaign where Undercommon is the default language, they're out of luck currently.
- There's no way to not spoil which language is being spoken, unless there was a simple way to check each character's language and @ then, but that's impractical.