### PR TITLE
Compatibility for when more tabs are added by other modules

### DIFF
--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -135,8 +135,6 @@ Hooks.on("renderChatLog", async function (chatLog, html, user) {
 
                     $("#" + tab + "Notification").hide();
                     break;
-                default:
-                    console.log("Unknown tab " + tab + "!");
             }
 
             $("#chat-log").scrollTop(9999999);
@@ -492,15 +490,18 @@ Hooks.on('ready', () => {
 });
 
 function setICNotifyProperties() {
-    $("#icNotification").css({'right': ($("div#sidebar.app").width() / 3 * 2).toString() + 'px'});
+    const nTabs = $("nav.tabbedchatlog.tabs > a.item").length;
+    $("#icNotification").css({'right': ($("div#sidebar.app").width() / nTabs * (nTabs - 1)).toString() + 'px'});
 };
 
 function setRollsNotifyProperties() {
-    $("#rollsNotification").css({'right': ($("div#sidebar.app").width() / 3).toString() + 'px'});
+    const nTabs = $("nav.tabbedchatlog.tabs > a.item").length;
+    $("#rollsNotification").css({'right': ($("div#sidebar.app").width() / nTabs * (nTabs - 2)).toString() + 'px'});
 };
 
 function setOOCNotifyProperties() {
-    //NO-OP Nothing to do
+    const nTabs = $("nav.tabbedchatlog.tabs > a.item").length;
+    $("#oocNotification").css({'right': ($("div#sidebar.app").width() / nTabs * (nTabs - 3)).toString() + 'px'});
 };
 
 function setALLTabsNotifyProperties() {


### PR DESCRIPTION
I am currently writing a module that adds another tab to the chatlog.  I wanted this to be compatible with tabbed chatlog, and with some hackery, I managed to get it to work.  There were only two minor issues, which this pull request attempts to solve...

1. Every time I switched to my custom tab, Tabbed Chatlog would report an error on the console.
2. The notification icons were being displayed in the wrong places.