### PR TITLE
Fix icChatInOoc in v10

### DIFF
--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -275,7 +275,7 @@ Hooks.on("preCreateChatMessage", (chatMessage, content) => {
                 content.type = CONST.CHAT_MESSAGE_TYPES.OOC
                 delete (content.speaker);
                 delete (chatMessage.data.speaker);
-                delete (chatMessage.data._source.speaker);
+                chatMessage.data._source.speaker = null;
                 console.log(chatMessage);
             }
         }


### PR DESCRIPTION
chatMessage.data._source becomes sealed in v10, so cannot delete chatMessage.data._source.speaker directly. Instead of call delete operator directly, assign null to chatMessage.data._source.speaker.